### PR TITLE
Add django-letsencrypt to project

### DIFF
--- a/morphgnt_api/settings.py
+++ b/morphgnt_api/settings.py
@@ -8,7 +8,10 @@ SECRET_KEY = 'g7j+tn)pjz_sw7j3$z_c*^6gwv43b7!%1&#!nt2)q2u&6i#@qx'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    "localhost",
+    "api.morphgnt.org"
+]
 
 
 # Application definition

--- a/morphgnt_api/settings.py
+++ b/morphgnt_api/settings.py
@@ -15,6 +15,7 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     "morphgnt_api",
+    "letsencrypt",
 ]
 MIDDLEWARE_CLASSES = []
 

--- a/morphgnt_api/urls.py
+++ b/morphgnt_api/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.conf.urls import include, url
 
 urlpatterns = [
     url(r"^v0/word/(?P<word_id>\d{11}).json$", "morphgnt_api.views.word", name="word"),
@@ -12,6 +12,8 @@ urlpatterns = [
     url(r"^v0/root.json$", "morphgnt_api.views.root", name="root"),
 
     url(r"^loaderio-97c892ba1d7ce63eb626ca62a7a0a961/$", "morphgnt_api.views.loader_verification"),
+
+    url(r"^\.well-known/", include("letsencrypt.urls")),
 
     url(r"^$", "morphgnt_api.views.home", name="home"),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8.2
+Django==1.8.18
 
 psycopg2==2.6
 gunicorn==19.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ psycopg2==2.6
 gunicorn==19.3.0
 
 dj-database-url==0.3.0
+
+django-letsencrypt==2.0.0


### PR DESCRIPTION
@jtauber: This PR is the first step in enabling Lets Encrypt for api.morphgnt.org.

Once these changes are merged and deployed, I can help facilitate getting a cert issued and installed.